### PR TITLE
[Bugfix] Reveal true token level errors instead of generic `Exception` without a message

### DIFF
--- a/proxy/convert_stream.py
+++ b/proxy/convert_stream.py
@@ -188,7 +188,3 @@ def to_generic_streaming_chunk(chunk: Any) -> GenericStreamingChunk:
         "tool_use": tool_use,
         "provider_specific_fields": provider_specific_fields,
     }
-
-
-# TODO Vibe-code a function that converts a complete ModelResponse into a GenericStreamingChunk as a single token
-#  containing the entire response for debugging purposes ?

--- a/proxy/convert_stream.py
+++ b/proxy/convert_stream.py
@@ -180,7 +180,7 @@ def to_generic_streaming_chunk(chunk: Any) -> GenericStreamingChunk:
         raise RuntimeError(f"Failed to convert ModelResponseStream to GenericStreamingChunk: {e}") from e
 
     return {
-        "text": text,
+        "txt": text,  # TODO Revert this key back to "text" after you debug the unspecific token level errors
         "is_finished": is_finished,
         "finish_reason": finish_reason,
         "usage": None,  # TODO Do we have to put anything here ?
@@ -188,3 +188,7 @@ def to_generic_streaming_chunk(chunk: Any) -> GenericStreamingChunk:
         "tool_use": tool_use,
         "provider_specific_fields": provider_specific_fields,
     }
+
+
+# TODO Vibe-code a function that converts a complete ModelResponse into a GenericStreamingChunk as a single token
+#  containing the entire response for debugging purposes ?

--- a/proxy/convert_stream.py
+++ b/proxy/convert_stream.py
@@ -180,7 +180,7 @@ def to_generic_streaming_chunk(chunk: Any) -> GenericStreamingChunk:
         raise RuntimeError(f"Failed to convert ModelResponseStream to GenericStreamingChunk: {e}") from e
 
     return {
-        "txt": text,  # TODO Revert this key back to "text" after you debug the unspecific token level errors
+        "txt": text,  # TODO Use this change, which breaks tokens, to verify that token related errors are informative
         "is_finished": is_finished,
         "finish_reason": finish_reason,
         "usage": None,  # TODO Do we have to put anything here ?

--- a/proxy/custom_llm_router.py
+++ b/proxy/custom_llm_router.py
@@ -160,6 +160,7 @@ class CustomLLMRouter(CustomLLM):
             )
         except Exception as e:
             raise RuntimeError(f"[ACOMPLETION] Error calling litellm.acompletion: {e}") from e
+
         return response
 
     def streaming(

--- a/proxy/custom_llm_router.py
+++ b/proxy/custom_llm_router.py
@@ -160,7 +160,6 @@ class CustomLLMRouter(CustomLLM):
             )
         except Exception as e:
             raise RuntimeError(f"[ACOMPLETION] Error calling litellm.acompletion: {e}") from e
-
         return response
 
     def streaming(


### PR DESCRIPTION
**UPDATE:** The solution was submitted as a different PR - https://github.com/BerriAI/litellm/pull/14379 - directly to the LiteLLM repo, while this PR will be kept around just to test the new version of LiteLLM later.

Example of a token-level error that does not provide any useful information:
```
common_request_processing.py:758 - litellm.proxy.proxy_server.async_data_generator(): Exception occured - 
Traceback (most recent call last):
  File "/home/mikey/Documents/Projects/claude-code-gpt-5/.venv/lib/python3.13/site-packages/litellm/proxy/common_request_processing.py", line 735, in async_sse_data_generator
    async for chunk in proxy_logging_obj.async_post_call_streaming_iterator_hook(
    ...<20 lines>...
        yield ProxyBaseLLMRequestProcessing.return_sse_chunk(chunk)
  File "/home/mikey/Documents/Projects/claude-code-gpt-5/.venv/lib/python3.13/site-packages/litellm/integrations/custom_logger.py", line 347, in async_post_call_streaming_iterator_hook
    async for item in response:
        yield item
  File "/home/mikey/Documents/Projects/claude-code-gpt-5/.venv/lib/python3.13/site-packages/litellm/integrations/custom_logger.py", line 347, in async_post_call_streaming_iterator_hook
    async for item in response:
        yield item
  File "/home/mikey/Documents/Projects/claude-code-gpt-5/.venv/lib/python3.13/site-packages/litellm/integrations/custom_logger.py", line 347, in async_post_call_streaming_iterator_hook
    async for item in response:
        yield item
  [Previous line repeated 2 more times]
  File "/home/mikey/Documents/Projects/claude-code-gpt-5/.venv/lib/python3.13/site-packages/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py", line 335, in async_anthropic_sse_wrapper
    async for chunk in self:
    ...<6 lines>...
            yield chunk
  File "/home/mikey/Documents/Projects/claude-code-gpt-5/.venv/lib/python3.13/site-packages/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py", line 190, in __anext__
    raise Exception
Exception

File "/home/mikey/Documents/Projects/claude-code-gpt-5/.venv/lib/python3.13/site-packages/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py", line 335, in async_anthropic_sse_wrapper
    async for chunk in self:
    ...<6 lines>...
            yield chunk
  File "/home/mikey/Documents/Projects/claude-code-gpt-5/.venv/lib/python3.13/site-packages/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py", line 190, in __anext__
    raise Exception
Exception
```